### PR TITLE
Remove all use of the sha256 hash for now

### DIFF
--- a/cmd/tkey-verification/api.go
+++ b/cmd/tkey-verification/api.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"crypto/ed25519"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -28,16 +27,16 @@ func NewAPI(devPath string) *API {
 }
 
 type Args struct {
-	UDI  [8]byte
-	Tag  string
-	Hash [sha256.Size]byte
+	UDI    [8]byte
+	Tag    string
+	PubKey []byte
 }
 
 func (a *API) Sign(args *Args, _ *struct{}) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	le.Printf("Going to sign hash from TKey with raw UDI: %s (tag: %s)\n", hex.EncodeToString(args.UDI[:]), args.Tag)
+	le.Printf("Going to sign public key from TKey with raw UDI: %s (tag: %s)\n", hex.EncodeToString(args.UDI[:]), args.Tag)
 
 	if args.Tag == "" {
 		err := fmt.Errorf("Empty tag")
@@ -45,14 +44,14 @@ func (a *API) Sign(args *Args, _ *struct{}) error {
 		return err
 	}
 
-	signature, err := signWithApp(a.devPath, signingPubKey, args.Hash)
+	signature, err := signWithApp(a.devPath, signingPubKey, args.PubKey)
 	if err != nil {
 		err = fmt.Errorf("signWithApp failed: %w", err)
 		le.Printf("%s\n", err)
 		return err
 	}
 
-	if !ed25519.Verify(signingPubKey, args.Hash[:], signature) {
+	if !ed25519.Verify(signingPubKey, args.PubKey, signature) {
 		err = fmt.Errorf("Signature failed verification")
 		le.Printf("%s\n", err)
 		return err

--- a/cmd/tkey-verification/main.go
+++ b/cmd/tkey-verification/main.go
@@ -74,7 +74,7 @@ func main() {
 Commands:
   serve-signer  TODO...
   remote-sign   TODO...
-  verify        Verify that a TKey is genuine by recreating the hash, fetching
+  verify        Verify that a TKey is genuine by extracting public key, fetching
                 the signature, and verifying it using the vendor's signing
                 public-key.
   show-pubkey   Output the public key of a TKey.`)

--- a/cmd/tkey-verification/remotesign.go
+++ b/cmd/tkey-verification/remotesign.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
 	"net/rpc"
@@ -33,9 +32,9 @@ func remoteSign(devPath string, verbose bool) {
 	}
 
 	args := Args{
-		UDI:  *(*[8]byte)(udi),
-		Tag:  signerAppTag,
-		Hash: sha256.Sum256(append(udi, pubKey...)),
+		UDI:    *(*[8]byte)(udi),
+		Tag:    signerAppTag,
+		PubKey: pubKey,
 	}
 
 	client := rpc.NewClient(conn)

--- a/cmd/tkey-verification/signerapp.go
+++ b/cmd/tkey-verification/signerapp.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -117,7 +116,7 @@ func runSignerApp(devPath string, verbose bool, appBin []byte) ([]byte, []byte, 
 // signWithApp connects to a TKey and asks an already running
 // signer-app to sign a message. The public key of signer-app must be
 // expectedPubKey.
-func signWithApp(devPath string, expectedPubKey []byte, message [sha256.Size]byte) ([]byte, error) {
+func signWithApp(devPath string, expectedPubKey []byte, message []byte) ([]byte, error) {
 	var err error
 	if devPath == "" {
 		devPath, err = util.DetectSerialPort(true)

--- a/cmd/tkey-verification/verify.go
+++ b/cmd/tkey-verification/verify.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"crypto/ed25519"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -18,8 +17,6 @@ func verify(devPath string, verbose bool) {
 		os.Exit(1)
 	}
 	fmt.Printf("TKey raw UDI: %s\n", hex.EncodeToString(udi))
-
-	hash := sha256.Sum256(append(udi, pubKey...))
 
 	// Get verification JSON by UDI
 	fn := fmt.Sprintf("%s/%s", signaturesDir, hex.EncodeToString(udi))
@@ -46,11 +43,11 @@ func verify(devPath string, verbose bool) {
 		os.Exit(1)
 	}
 
-	if !ed25519.Verify(signingPubKey, hash[:], vSignature) {
+	if !ed25519.Verify(signingPubKey, pubKey, vSignature) {
 		fmt.Printf("Signature failed verification!\n")
 		os.Exit(1)
 	}
-	fmt.Printf("Verified signature over computed hash, TKey is genuine!\n")
+	fmt.Printf("Verified signature over device public key, TKey is genuine!\n")
 
 	os.Exit(0)
 }


### PR DESCRIPTION
Instead, send the UDI and the public key unhashed to the signer. Sign directly over the public key.

If we later decide to publish something on sigsum we can decide that then and let the signer store something.