### PR TITLE
Add a challenge to signing and verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ workstation.
 `tkey-verification remote-sign` is run on the provisioning workstation
 to retrieve the Unique Device Identifier (UDI), load the signer, and
 ask the signer to sign a random challenge. It then sends the UDI, the
-challenge, and the device signature to the signing server above for a
-vendor signature.
+challenge, and the device signature to the signing server, which will
+make the vendor signature.
 
 The signing server signs the message (the device signature) and
 outputs a file in a directory `signatures/` which is named after the
@@ -175,7 +175,7 @@ it in `cmd/tkey-verification/app.bin` before building the tool.
     App loaded.
     App name0:'tk1 ' name1:'sign' version:1
     TKey raw UDI: 0133704100000015
-    Verified the vendor signature over a device signature over the UDI, TKey is genuine!
+    Verified the vendor signature over a device signature over the challenge, TKey is genuine!
     ```
 
 ## Running qemu

--- a/cmd/tkey-verification/api.go
+++ b/cmd/tkey-verification/api.go
@@ -27,9 +27,10 @@ func NewAPI(devPath string) *API {
 }
 
 type Args struct {
-	UDI     [8]byte
-	Tag     string
-	Message []byte
+	UDI       [8]byte
+	Tag       string
+	Challenge []byte
+	Message   []byte
 }
 
 func (a *API) Sign(args *Args, _ *struct{}) error {
@@ -68,6 +69,7 @@ func (a *API) Sign(args *Args, _ *struct{}) error {
 	json, err := json.Marshal(Verification{
 		time.Now().UTC().Format(time.RFC3339),
 		args.Tag,
+		hex.EncodeToString(args.Challenge),
 		hex.EncodeToString(signature),
 	})
 	if err != nil {

--- a/cmd/tkey-verification/api.go
+++ b/cmd/tkey-verification/api.go
@@ -27,9 +27,9 @@ func NewAPI(devPath string) *API {
 }
 
 type Args struct {
-	UDI    [8]byte
-	Tag    string
-	PubKey []byte
+	UDI     [8]byte
+	Tag     string
+	Message []byte
 }
 
 func (a *API) Sign(args *Args, _ *struct{}) error {
@@ -44,14 +44,14 @@ func (a *API) Sign(args *Args, _ *struct{}) error {
 		return err
 	}
 
-	signature, err := signWithApp(a.devPath, signingPubKey, args.PubKey)
+	signature, err := signWithApp(a.devPath, signingPubKey, args.Message)
 	if err != nil {
 		err = fmt.Errorf("signWithApp failed: %w", err)
 		le.Printf("%s\n", err)
 		return err
 	}
 
-	if !ed25519.Verify(signingPubKey, args.PubKey, signature) {
+	if !ed25519.Verify(signingPubKey, args.Message, signature) {
 		err = fmt.Errorf("Signature failed verification")
 		le.Printf("%s\n", err)
 		return err

--- a/cmd/tkey-verification/remotesign.go
+++ b/cmd/tkey-verification/remotesign.go
@@ -17,6 +17,13 @@ func remoteSign(devPath string, verbose bool) {
 	}
 	le.Printf("TKey raw UDI: %s\n", hex.EncodeToString(udi))
 
+	// Sign the UDI
+	message, err := signWithApp(devPath, pubKey, udi)
+	if err != nil {
+		le.Printf("local sign failed: %s", err)
+		os.Exit(1)
+	}
+
 	tlsConfig := tls.Config{
 		Certificates: []tls.Certificate{
 			loadCert(clientCertFile, clientKeyFile),
@@ -32,9 +39,9 @@ func remoteSign(devPath string, verbose bool) {
 	}
 
 	args := Args{
-		UDI:    *(*[8]byte)(udi),
-		Tag:    signerAppTag,
-		PubKey: pubKey,
+		UDI:     *(*[8]byte)(udi),
+		Tag:     signerAppTag,
+		Message: message,
 	}
 
 	client := rpc.NewClient(conn)

--- a/cmd/tkey-verification/remotesign.go
+++ b/cmd/tkey-verification/remotesign.go
@@ -25,7 +25,8 @@ func remoteSign(devPath string, verbose bool) {
 		os.Exit(1)
 	}
 
-	// The message we want vendor to sign is the result of signing the challenge
+	// The message we want vendor to sign is our signature over the
+	// challenge
 	message, err := signWithApp(devPath, pubKey, challenge)
 	if err != nil {
 		le.Printf("local sign failed: %s", err)

--- a/cmd/tkey-verification/servesigner.go
+++ b/cmd/tkey-verification/servesigner.go
@@ -16,6 +16,7 @@ import (
 type Verification struct {
 	Timestamp string `json:"timestamp"`
 	Tag       string `json:"tag"`
+	Challenge string `json:"challenge"`
 	Signature string `json:"signature"`
 }
 

--- a/cmd/tkey-verification/signerapp.go
+++ b/cmd/tkey-verification/signerapp.go
@@ -163,7 +163,7 @@ func signWithApp(devPath string, expectedPubKey []byte, message []byte) ([]byte,
 		return nil, fmt.Errorf("TKey does not have the expected pubkey")
 	}
 
-	signature, err := tkSigner.Sign(message[:])
+	signature, err := tkSigner.Sign(message)
 	if err != nil {
 		return nil, fmt.Errorf("Sign failed: %w", err)
 	}

--- a/cmd/tkey-verification/verify.go
+++ b/cmd/tkey-verification/verify.go
@@ -18,6 +18,13 @@ func verify(devPath string, verbose bool) {
 	}
 	fmt.Printf("TKey raw UDI: %s\n", hex.EncodeToString(udi))
 
+	// Get a signature over the UDI as the message to be verified
+	message, err := signWithApp(devPath, pubKey, udi)
+	if err != nil {
+		le.Printf("sign failed: %s", err)
+		os.Exit(1)
+	}
+
 	// Get verification JSON by UDI
 	fn := fmt.Sprintf("%s/%s", signaturesDir, hex.EncodeToString(udi))
 	verificationJSON, err := os.ReadFile(fn)
@@ -43,11 +50,11 @@ func verify(devPath string, verbose bool) {
 		os.Exit(1)
 	}
 
-	if !ed25519.Verify(signingPubKey, pubKey, vSignature) {
+	if !ed25519.Verify(signingPubKey, message, vSignature) {
 		fmt.Printf("Signature failed verification!\n")
 		os.Exit(1)
 	}
-	fmt.Printf("Verified signature over device public key, TKey is genuine!\n")
+	fmt.Printf("Verified the vendor signature over a local signature over the UDI, TKey is genuine!\n")
 
 	os.Exit(0)
 }

--- a/cmd/tkey-verification/verify.go
+++ b/cmd/tkey-verification/verify.go
@@ -18,13 +18,6 @@ func verify(devPath string, verbose bool) {
 	}
 	fmt.Printf("TKey raw UDI: %s\n", hex.EncodeToString(udi))
 
-	// Get a signature over the UDI as the message to be verified
-	message, err := signWithApp(devPath, pubKey, udi)
-	if err != nil {
-		le.Printf("sign failed: %s", err)
-		os.Exit(1)
-	}
-
 	// Get verification JSON by UDI
 	fn := fmt.Sprintf("%s/%s", signaturesDir, hex.EncodeToString(udi))
 	verificationJSON, err := os.ReadFile(fn)
@@ -44,6 +37,19 @@ func verify(devPath string, verbose bool) {
 		os.Exit(1)
 	}
 
+	// Get a signature over the challenge as the message to be verified
+	challenge, err := hex.DecodeString(verification.Challenge)
+	if err != nil {
+		le.Printf("Couldn't decode challenge: %s", err)
+		os.Exit(1)
+	}
+
+	message, err := signWithApp(devPath, pubKey, challenge)
+	if err != nil {
+		le.Printf("sign failed: %s", err)
+		os.Exit(1)
+	}
+
 	vSignature, err := hex.DecodeString(verification.Signature)
 	if err != nil {
 		le.Printf("hex.DecodeString failed: %s", err)
@@ -54,7 +60,7 @@ func verify(devPath string, verbose bool) {
 		fmt.Printf("Signature failed verification!\n")
 		os.Exit(1)
 	}
-	fmt.Printf("Verified the vendor signature over a local signature over the UDI, TKey is genuine!\n")
+	fmt.Printf("Verified the vendor signature over a device signature over the challenge, TKey is genuine!\n")
 
 	os.Exit(0)
 }


### PR DESCRIPTION
The message to be signed by the vendor key is changed to be the result of a sign operation on the device's own UDI.

The verification is changed to:

- load signer
- ask signer to sign UDI
- use result as message when verifiying vendor signature