### PR TITLE
Remove published challenge, sign device public key

### DIFF
--- a/cmd/tkey-verification/api.go
+++ b/cmd/tkey-verification/api.go
@@ -32,10 +32,9 @@ func (a *API) Ping(_ *struct{}, _ *struct{}) error {
 }
 
 type Args struct {
-	UDI       [8]byte // BE
-	Tag       string
-	Challenge []byte
-	Message   []byte
+	UDI     [8]byte // BE
+	Tag     string
+	Message []byte
 }
 
 func (a *API) Sign(args *Args, _ *struct{}) error {
@@ -74,7 +73,6 @@ func (a *API) Sign(args *Args, _ *struct{}) error {
 	json, err := json.Marshal(Verification{
 		time.Now().UTC().Format(time.RFC3339),
 		args.Tag,
-		hex.EncodeToString(args.Challenge),
 		hex.EncodeToString(signature),
 	})
 	if err != nil {

--- a/cmd/tkey-verification/servesigner.go
+++ b/cmd/tkey-verification/servesigner.go
@@ -16,7 +16,6 @@ import (
 type Verification struct {
 	Timestamp string `json:"timestamp"`
 	Tag       string `json:"tag"`
-	Challenge string `json:"challenge"`
 	Signature string `json:"signature"`
 }
 

--- a/cmd/tkey-verification/verify.go
+++ b/cmd/tkey-verification/verify.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -37,30 +38,38 @@ func verify(devPath string, verbose bool) {
 		os.Exit(1)
 	}
 
-	// Get a signature over the challenge as the message to be verified
-	challenge, err := hex.DecodeString(verification.Challenge)
-	if err != nil {
-		le.Printf("Couldn't decode challenge: %s", err)
-		os.Exit(1)
-	}
-
-	message, err := signWithApp(devPath, pubKey, challenge)
-	if err != nil {
-		le.Printf("sign failed: %s", err)
-		os.Exit(1)
-	}
-
+	// Check the vendor signature over the device public key
 	vSignature, err := hex.DecodeString(verification.Signature)
 	if err != nil {
 		le.Printf("hex.DecodeString failed: %s", err)
 		os.Exit(1)
 	}
 
-	if !ed25519.Verify(signingPubKey, message, vSignature) {
-		fmt.Printf("Signature failed verification!\n")
+	if !ed25519.Verify(signingPubKey, pubKey, vSignature) {
+		le.Printf("Vendor signature failed verification!")
 		os.Exit(1)
 	}
-	fmt.Printf("Verified the vendor signature over a device signature over the challenge, TKey is genuine!\n")
+
+	// Get a device signature over a random challenge
+	challenge := make([]byte, 32)
+	if _, err = rand.Read(challenge); err != nil {
+		le.Printf("rand.Read failed: %s", err)
+		os.Exit(1)
+	}
+
+	signature, err := signWithApp(devPath, pubKey, challenge)
+	if err != nil {
+		le.Printf("sign failed: %s", err)
+		os.Exit(1)
+	}
+
+	// Verify device signature against device public key
+	if !ed25519.Verify(pubKey, challenge, signature) {
+		le.Printf("Vendor signature failed verification!")
+		os.Exit(1)
+	}
+
+	fmt.Printf("TKey is genuine!\n")
 
 	os.Exit(0)
 }


### PR DESCRIPTION
Change the way we do signing and verification:

- generate a random challenge every time we want to verify the device under verification.

- publish a vendor signature of the device's public key, but not the device public key itself.

When verifiying a device we extract the public key from the device and check the published vendor signature over it. If correct, we proceed.

Then we generate a random challenge and have the device sign it. We verify the signature against the already verified device public key. If this signature verifies the TKey has proved that it's in posession of the corresponding private key and is a genuine TKey.